### PR TITLE
Add equipment transition tracking to parser

### DIFF
--- a/agent/prompts/parser.py
+++ b/agent/prompts/parser.py
@@ -71,10 +71,50 @@ Factors that reduce confidence:
 - Missing or inconsistent lane interval counts
 - Unusual formatting that deviates from typical coach patterns
 
+## Equipment Transitions
+
+Equipment is **stateful** — maintain a running `active_equipment` list as you parse top-to-bottom.
+
+### Rules
+1. **"X On"** adds X to active equipment: "Fins On" → active = ["Fins"]
+2. **"X Off"** removes X: "Fins Off" → active = []
+3. **Compound transitions** combine additions and removals in one line:
+   - "Fins Off, Pads & Buoy On" → remove Fins, add Paddles + Pull Buoy → active = ["Paddles", "Pull Buoy"]
+4. **"All Off"** or bare "Off" clears all equipment → active = []
+5. **Equipment transitions create section boundaries** — start a new section when equipment changes.
+6. Sets inherit the current `active_equipment` into their `equipment` field.
+7. The section's `equipment_context` must match the active equipment for that section.
+
+### Equipment name mapping
+Use the canonical names from the conventions (e.g., "Paddles" not "Pads", "Pull Buoy" not "Buoy"). \
+Common mappings: Fins → Fins, Pads/Pad → Paddles, Buoy/B → Pull Buoy.
+
+### Example
+Given this email text:
+```
+Warm Up:
+400 Ch
+4x75 K R:10
+
+Fins On
+3x100 (50K+50Sw) @1:40-2:10
+
+Fins Off, Pads & Buoy On
+4x75 Sw @1:10-1:30
+
+Pads & Buoy Off
+Warm Down:
+200 Ch
+```
+
+Parse as these sections:
+- Section "Warm Up" — equipment_context: [], sets have equipment: []
+- Section "Fins Kick/Swim" — equipment_context: ["Fins"], sets have equipment: ["Fins"]
+- Section "Paddles & Buoy Swim" — equipment_context: ["Paddles", "Pull Buoy"], sets have equipment: ["Paddles", "Pull Buoy"]
+- Section "Warm Down" — equipment_context: [], sets have equipment: []
+
 ## Key Rules
 
-- **Equipment transitions**: Lines like "Fins On", "Fins Off, Pads & Buoy On" create equipment \
-context that applies to subsequent sets until the next transition.
 - **Named variants**: A line with swimmer names (e.g., "Patricia/Will/Dustin") followed by \
 different sets = a variant workout. Store it in the `variants` array.
 - **Preserve original notation**: Store both canonical names (stroke="Kick") and shorthand \

--- a/agent/tools/validation.py
+++ b/agent/tools/validation.py
@@ -7,6 +7,7 @@ import json
 from shared.schema import LaneIntervals, Workout, YardageEstimate
 
 LANE_KEYS = ["L6", "L5", "L4", "L3", "L2", "L1"]
+KNOWN_EQUIPMENT = {"Fins", "Paddles", "Pull Buoy"}
 
 
 def _parse_lane_reps(lane_rep_counts: LaneIntervals | None, default_repeats: int) -> dict[str, int]:
@@ -103,6 +104,34 @@ def validate_workout(workout_json: str) -> str:
                 warnings.append(
                     f"Repeat count {s.repeats} in '{section.name}' seems very high."
                 )
+
+    # Check equipment consistency
+    for section in workout.sections:
+        ctx = section.equipment_context
+        for s in section.sets:
+            if ctx and not s.equipment:
+                warnings.append(
+                    f"Section '{section.name}' has equipment_context {ctx} but a set "
+                    f"has empty equipment. Sets should inherit from equipment_context."
+                )
+                break  # One warning per section is enough
+            if s.equipment and ctx and set(s.equipment) != set(ctx):
+                warnings.append(
+                    f"Section '{section.name}': set equipment {s.equipment} doesn't match "
+                    f"equipment_context {ctx}."
+                )
+                break
+
+        # Check for unknown equipment names
+        all_equip = set(ctx)
+        for s in section.sets:
+            all_equip.update(s.equipment)
+        unknown = all_equip - KNOWN_EQUIPMENT
+        if unknown:
+            warnings.append(
+                f"Section '{section.name}' has unknown equipment: {sorted(unknown)}. "
+                f"Known equipment: {sorted(KNOWN_EQUIPMENT)}."
+            )
 
     # Calculate yardage
     yardage = calculate_yardage(workout)

--- a/tests/test_parser_prompt.py
+++ b/tests/test_parser_prompt.py
@@ -107,6 +107,36 @@ def test_prompt_warns_against_wrong_field_names():
     assert "rest_type" in PARSER_SYSTEM_PROMPT  # warns against this mistake
 
 
+def test_prompt_has_equipment_transition_section():
+    """Parser prompt must have a dedicated equipment transitions section."""
+    assert "## Equipment Transitions" in PARSER_SYSTEM_PROMPT
+    assert "active_equipment" in PARSER_SYSTEM_PROMPT
+
+
+def test_prompt_has_equipment_state_rules():
+    """Parser prompt must document stateful equipment tracking rules."""
+    prompt = PARSER_SYSTEM_PROMPT
+    # On/Off rules
+    assert "On" in prompt and "Off" in prompt
+    assert "Fins On" in prompt
+    assert "Fins Off" in prompt
+    # Compound transitions
+    assert "Pads & Buoy On" in prompt
+    # Section boundary rule
+    assert "section boundaries" in prompt.lower() or "section boundary" in prompt.lower()
+    # Inheritance
+    assert "equipment_context" in prompt
+
+
+def test_prompt_has_equipment_transition_example():
+    """Parser prompt must include a concrete equipment transition parsing example."""
+    prompt = PARSER_SYSTEM_PROMPT
+    # Should show multi-section flow with equipment changes
+    assert "Fins Kick/Swim" in prompt or "equipment_context" in prompt
+    assert '["Fins"]' in prompt
+    assert '["Paddles", "Pull Buoy"]' in prompt
+
+
 def test_prompt_has_example():
     """Parser prompt must include a concrete JSON example."""
     assert '"Kick"' in PARSER_SYSTEM_PROMPT

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -158,6 +158,90 @@ def test_validate_workout_includes_yardage_json():
     assert '"estimated": 1000' in result
 
 
+def test_validate_equipment_context_without_set_equipment():
+    """Warn when section has equipment_context but sets have empty equipment."""
+    workout = Workout(
+        sections=[
+            Section(
+                name="Fins Set",
+                equipment_context=["Fins"],
+                sets=[SetItem(repeats=3, distance=100, stroke="Kick", equipment=[])],
+            ),
+        ],
+    )
+    result = validate_workout(workout.model_dump_json())
+    assert "equipment_context" in result
+    assert "empty equipment" in result
+
+
+def test_validate_equipment_consistent():
+    """No equipment warnings when section context matches set equipment."""
+    workout = Workout(
+        workout_type=WorkoutType.AEROBIC,
+        sections=[
+            Section(
+                name="Warm Up",
+                sets=[SetItem(repeats=1, distance=400, stroke="Choice")],
+            ),
+            Section(
+                name="Fins Kick",
+                equipment_context=["Fins"],
+                sets=[
+                    SetItem(repeats=3, distance=100, stroke="Kick", equipment=["Fins"]),
+                ],
+            ),
+            Section(
+                name="Warm Down",
+                sets=[SetItem(repeats=1, distance=200, stroke="Choice")],
+            ),
+        ],
+    )
+    result = validate_workout(workout.model_dump_json())
+    assert "equipment_context" not in result
+    assert "empty equipment" not in result
+
+
+def test_validate_equipment_mismatch():
+    """Warn when set equipment doesn't match section equipment_context."""
+    workout = Workout(
+        sections=[
+            Section(
+                name="Paddles Set",
+                equipment_context=["Paddles"],
+                sets=[
+                    SetItem(
+                        repeats=4, distance=75, stroke="Swim",
+                        equipment=["Fins"],  # Mismatch!
+                    ),
+                ],
+            ),
+        ],
+    )
+    result = validate_workout(workout.model_dump_json())
+    assert "doesn't match" in result or "doesn't match" in result.replace("\u2019", "'")
+
+
+def test_validate_unknown_equipment():
+    """Warn when equipment names are not in the known set."""
+    workout = Workout(
+        sections=[
+            Section(
+                name="Snorkel Set",
+                equipment_context=["Snorkel"],
+                sets=[
+                    SetItem(
+                        repeats=4, distance=100, stroke="Swim",
+                        equipment=["Snorkel"],
+                    ),
+                ],
+            ),
+        ],
+    )
+    result = validate_workout(workout.model_dump_json())
+    assert "unknown equipment" in result.lower()
+    assert "Snorkel" in result
+
+
 def test_flag_unknown():
     result = flag_unknown("TX", "50K+50Sw TX", "unknown_abbreviation")
     assert "TX" in result


### PR DESCRIPTION
## Summary
- Expanded parser prompt with a dedicated **Equipment Transitions** section: stateful tracking rules (On/Off, compound transitions like "Fins Off, Pads & Buoy On"), section boundary creation on equipment changes, canonical name mapping, and a concrete multi-section parsing example
- Added **equipment consistency validation** to `validate_workout`: warns on missed inheritance (equipment_context set but sets empty), context/set mismatches, and unknown equipment names
- Added 7 new tests (3 prompt, 4 validation)

Closes #13

## Test plan
- [x] All 48 tests pass (`uv run python -m pytest tests/ -v`)
- [ ] Parse a real coach email with equipment transitions to verify improved output

🤖 Generated with [Claude Code](https://claude.com/claude-code)