### PR TITLE
Switch cloudbuild.yaml to Artifact Registry

### DIFF
--- a/agent/tools/validation.py
+++ b/agent/tools/validation.py
@@ -131,34 +131,6 @@ def validate_workout(workout_json: str) -> str:
                 f"Known equipment: {sorted(KNOWN_EQUIPMENT)}."
             )
 
-    # Check equipment consistency
-    for section in workout.sections:
-        ctx = section.equipment_context
-        for s in section.sets:
-            if ctx and not s.equipment:
-                warnings.append(
-                    f"Section '{section.name}' has equipment_context {ctx} but a set "
-                    f"has empty equipment. Sets should inherit from equipment_context."
-                )
-                break  # One warning per section is enough
-            if s.equipment and ctx and set(s.equipment) != set(ctx):
-                warnings.append(
-                    f"Section '{section.name}': set equipment {s.equipment} doesn't match "
-                    f"equipment_context {ctx}."
-                )
-                break
-
-        # Check for unknown equipment names
-        all_equip = set(ctx)
-        for s in section.sets:
-            all_equip.update(s.equipment)
-        unknown = all_equip - KNOWN_EQUIPMENT
-        if unknown:
-            warnings.append(
-                f"Section '{section.name}' has unknown equipment: {sorted(unknown)}. "
-                f"Known equipment: {sorted(KNOWN_EQUIPMENT)}."
-            )
-
     # Calculate yardage
     yardage = calculate_yardage(workout)
     total = yardage.estimated or 0

--- a/agent/tools/validation.py
+++ b/agent/tools/validation.py
@@ -131,6 +131,34 @@ def validate_workout(workout_json: str) -> str:
                 f"Known equipment: {sorted(KNOWN_EQUIPMENT)}."
             )
 
+    # Check equipment consistency
+    for section in workout.sections:
+        ctx = section.equipment_context
+        for s in section.sets:
+            if ctx and not s.equipment:
+                warnings.append(
+                    f"Section '{section.name}' has equipment_context {ctx} but a set "
+                    f"has empty equipment. Sets should inherit from equipment_context."
+                )
+                break  # One warning per section is enough
+            if s.equipment and ctx and set(s.equipment) != set(ctx):
+                warnings.append(
+                    f"Section '{section.name}': set equipment {s.equipment} doesn't match "
+                    f"equipment_context {ctx}."
+                )
+                break
+
+        # Check for unknown equipment names
+        all_equip = set(ctx)
+        for s in section.sets:
+            all_equip.update(s.equipment)
+        unknown = all_equip - KNOWN_EQUIPMENT
+        if unknown:
+            warnings.append(
+                f"Section '{section.name}' has unknown equipment: {sorted(unknown)}. "
+                f"Known equipment: {sorted(KNOWN_EQUIPMENT)}."
+            )
+
     # Calculate yardage
     yardage = calculate_yardage(workout)
     total = yardage.estimated or 0

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,11 @@
 steps:
   # Build the container image
   - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/adk-workout-agent:$COMMIT_SHA", "."]
+    args: ["build", "-t", "us-east1-docker.pkg.dev/$PROJECT_ID/docker-images/adk-workout-agent:$COMMIT_SHA", "."]
 
   # Push to Container Registry
   - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "gcr.io/$PROJECT_ID/adk-workout-agent:$COMMIT_SHA"]
+    args: ["push", "us-east1-docker.pkg.dev/$PROJECT_ID/docker-images/adk-workout-agent:$COMMIT_SHA"]
 
   # Deploy to Cloud Run
   - name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
@@ -15,7 +15,7 @@ steps:
       - "deploy"
       - "adk-workout-agent"
       - "--image"
-      - "gcr.io/$PROJECT_ID/adk-workout-agent:$COMMIT_SHA"
+      - "us-east1-docker.pkg.dev/$PROJECT_ID/docker-images/adk-workout-agent:$COMMIT_SHA"
       - "--region"
       - "us-east1"
       - "--platform"
@@ -35,4 +35,4 @@ steps:
       - "--allow-unauthenticated"
 
 images:
-  - "gcr.io/$PROJECT_ID/adk-workout-agent:$COMMIT_SHA"
+  - "us-east1-docker.pkg.dev/$PROJECT_ID/docker-images/adk-workout-agent:$COMMIT_SHA"


### PR DESCRIPTION
## Summary
- Replaced deprecated `gcr.io` Container Registry URLs with `us-east1-docker.pkg.dev` Artifact Registry
- Fixes rate limit errors during `docker push` in Cloud Build

## Test plan
- [x] Successfully deployed to Cloud Run using Artifact Registry during initial deploy
- [x] Health endpoint returns `{"status":"ok"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)